### PR TITLE
Move SkyBridge into the Alternative Clients category and adjust its description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Always use an app password, never your main password!
  - [Graysky](https://graysky.app/) - Mobile client for both Android and iOS
  - [Skeetdeck](https://skeetdeck.pages.dev/) - Web client inspired by TweetDeck
  - [Skeets](https://www.skeetsapp.com/) - Client for iOS / iPadOS / macOS
+ - [SkyBridge](https://skybridge.fly.dev/) - Proxy between Bluesky and Mastodon clients
  - [TOKIMEKI](https://tokimekibluesky.vercel.app/) - Web client
 
 ## Charts, graphs, and stats
@@ -39,7 +40,6 @@ Always use an app password, never your main password!
 ## Posts
  - [Profile Cleaner](https://bsky.jazco.dev/cleanup) - A tool to clean up old posts, likes, and reposts
  - [skeetgen](https://codeberg.org/mary-ext/skeetgen) - Generate an easily viewable archive of your Bluesky posts
- - [SkyBridge](https://skybridge.fly.dev/) - Proxy between Bluesky and Mastodon
  - [SkySweeper](https://skysweeper.p8.lu/) - Automatically delete old posts
 
 ## Profile

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Always use an app password, never your main password!
  - [Graysky](https://graysky.app/) - Mobile client for both Android and iOS
  - [Skeetdeck](https://skeetdeck.pages.dev/) - Web client inspired by TweetDeck
  - [Skeets](https://www.skeetsapp.com/) - Client for iOS / iPadOS / macOS
- - [SkyBridge](https://skybridge.fly.dev/) - Proxy between Bluesky and Mastodon clients
+ - [SkyBridge](https://skybridge.fly.dev/) - Proxy to use Bluesky with Mastodon clients
  - [TOKIMEKI](https://tokimekibluesky.vercel.app/) - Web client
 
 ## Charts, graphs, and stats


### PR DESCRIPTION
SkyBridge is much closer to a client than a post manager, and it doesn't connect to Mastodon itself but provides a "Mastodon API" compatible client API.