### PR TITLE
More accurate wording regarding Bridgy Fed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Always use an app password, never your main password!
  - [TOKIMEKI](https://tokimekibluesky.vercel.app/) - Web client
 
 ## Bridges
- - [Bridgy Fed](https://fed.brid.gy) - Connects ATProto handles to ActivityPub (Mastodon, …) and ActivityPub accounts to ATProto (Bluesky)
+ - [Bridgy Fed](https://fed.brid.gy) - Connects ATProto indentities to ActivityPub (Mastodon, …) and ActivityPub actors to ATProto (Bluesky)
 
 ## Charts, graphs, and stats
  - [Atlas](https://bsky.jazco.dev/) - Aggregate stats for all posts


### PR DESCRIPTION
Since I submitted this entry, I should take care that it's accurate.

Bridgy Fed does in fact track stable identities, not handles, on the Bluesky side, and on the ActivityPub side not everything is an "account" since an ActivityPub actor is a very broad concept.