### PR TITLE
Update README.md for new jetstream repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This protocol enables the creation of powerful third party tools, enlisted here 
  - [Bluesky, and what Bluesky is not.](https://whtwnd.com/alexia.bsky.cyrneko.eu/3l727v7zlis2i) - An overview of Bluesky and the AT Protocol targeted at ActivityPub developers
 
 ## Selfhosting
- - [jetstream](https://github.com/ericvolp12/jetstream) - A simplified JSON event stream for AT Proto
+ - [[jetstream](https://github.com/ericvolp12/jetstream)](https://github.com/bluesky-social/jetstream) - A simplified JSON event stream for AT Proto
  - [PDS](https://github.com/bluesky-social/pds) - Container image and documentation to selfhost your own Personal Data Server
 
 ## Viewers


### PR DESCRIPTION
From the [original](https://github.com/ericvolp12/jetstream?tab=readme-ov-file):

> FYI: Jetstream is now being maintained in the [bsky-social](https://github.com/bluesky-social/jetstream) org. This repo will stick around as an artifact but the fork in bsky-social is where I'll be making active updates.

Repointing that link to the new and updated repo under the Bluesky org