### PR TITLE
Add Bluesky Navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This protocol enables the creation of powerful third party tools, enlisted here 
  - [Skeetdeck](https://skeetdeck.pages.dev/) - Web client inspired by TweetDeck
  - [Tabtter](https://tabtter.jp/) - Decentralized SNS client supporting Bluesky, Mastodon, and Misskey
  - [TOKIMEKI](https://tokimekibluesky.vercel.app/) - Web client
+- [Bluesky Navigator](https://github.com/tonycpsu/bluesky-navigator) - Userscript that adds keyboard shortcuts, read post tracking, and more to the native Bluesky web interface
 
 ## Bridges
  - [Bridgy Fed](https://fed.brid.gy) - Connects ATProto identities to ActivityPub (Mastodon, …) and ActivityPub actors to ATProto (Bluesky)


### PR DESCRIPTION
I wrote a Userscript for Tampermonkey etc. to augment the built-in Bluesky web interface with some extra functionality. Not really a web client by itself but I don't think a new section is warranted so I'm lumping it in with the other web clients.