### PR TITLE
Improve TOKIMEKI description, update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This protocol enables the creation of powerful third party tools, enlisted here 
  - [Klearsky](https://klearsky.pages.dev/) - Web client (Japanese & English)
  - [Skeetdeck](https://skeetdeck.pages.dev/) - Web client inspired by TweetDeck
  - [Tabtter](https://tabtter.jp/) - Decentralized SNS client supporting Bluesky, Mastodon, and Misskey
- - [TOKIMEKI](https://tokimekibluesky.vercel.app/) - Web client
+ - [TOKIMEKI](https://tokimeki.blue/) - Highly customizable web client, also available as an Android app (Japanese & English)
 - [Bluesky Navigator](https://github.com/tonycpsu/bluesky-navigator) - Userscript that adds keyboard shortcuts, read post tracking, and more to the native Bluesky web interface
 
 ## Bridges


### PR DESCRIPTION
I use that site to monitor how my feeds are doing and felt like giving a less boring description for that app here. The site now has its own domain at <https://tokimeki.blue/>.

Also added "Japanese & English" at the end as those are the 2 main languages used on the app and its [docs site](https://docs.tokimeki.blue).