### PR TITLE
feat(docs): Wamellow Discord Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This protocol enables the creation of powerful third party tools, enlisted here 
  - [Blue Bots, Done Quick!](https://bluebotsdonequick.com/) - Create your own Bluesky bot!
  - [Croissant](https://apps.apple.com/us/app/croissant-cross-posting/id6670288979) - Cross-post to Bluesky, Threads and Mastodon - iOS
  - [Profile Cleaner](https://bsky.jazco.dev/cleanup) - A tool to clean up old posts, likes, and reposts
+ - [Wamellow Discord Bot](https://wamellow.com/docs/notifications) - Get Bluesky posts into Discord, as they happen, with filters and pings
  - [Skeet Discord Bot](https://github.com/malooski/skeet-discord-bot) - Posts your bluesky skeets to Discord
  - [skeetgen](https://codeberg.org/mary-ext/skeetgen) - Generate an easily viewable archive of your Bluesky posts
  - [SkySweeper](https://skysweeper.p8.lu/) - Automatically delete old posts


### PR DESCRIPTION
Adds the Wamellow Discord Bot as an auto-poster for Bluesky -> Discord

>https://www.reddit.com/r/wamellow/comments/1hnbwsr/how_to_get_bluesky_post_into_discord/
>https://wamellow.com/docs/notifications

![A message of a Bluesky post in a Discord channel sent by Wamellow.com](https://github.com/user-attachments/assets/9aeb6be6-3f3e-489e-a081-f6d10ae5b9f1)